### PR TITLE
NSC-8559 yarnのバージョンが現時点での最新になるように変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
 FROM node:10.15.2-alpine
 
-ENV NPM_CONFIG_PREFIX="/home/node/.npm-global" \
-  PATH="$PATH:/home/node/.npm-global/bin"
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin
+ENV YARN_VERSION 1.13.0
 
 RUN set -x && \
-  npm install -g npm && \
-  npm install -g yarn && \
-  apk add --update --no-cache tzdata && \
+  apk add --update --no-cache tzdata --virtual .build-deps-yarn curl && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   echo "Asia/Tokyo" > /etc/timezone && \
-  apk del tzdata
+  apk del tzdata && \
+  curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" && \
+  tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ && \
+  ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn && \
+  ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg && \
+  rm yarn-v$YARN_VERSION.tar.gz && \
+  apk del .build-deps-yarn && \
+  npm install --global npm@6.9.0
 
 USER node
 


### PR DESCRIPTION
# 課題URL（JIRAかGitHub issue）
https://smsc-co-ltd.atlassian.net/browse/NSC-8559

# PRのDoneの定義
- https://smsc-co-ltd.atlassian.net/browse/NSC-8559 の完了条件が満たされている事

# 変更点概要
- yarnのバージョンが最新になるように変更
- ENVは無理に1行にまとめなくてもDockerのレイヤーは増えないので複数行で書くように変更

# 補足情報
単純に `npm install -g yarn` ではバージョンが上がらない（実行ユーザー毎に npm packageが管理されている為）公式サイトにある対応を行いました。

https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md